### PR TITLE
Nounsの名称をAsoUbuyama Nounsに変更する。

### DIFF
--- a/packages/nouns-contracts/contracts/NounsToken.sol
+++ b/packages/nouns-contracts/contracts/NounsToken.sol
@@ -106,7 +106,7 @@ contract NounsToken is INounsToken, Ownable, ERC721Checkpointable {
         INounsDescriptorMinimal _descriptor,
         INounsSeeder _seeder,
         IProxyRegistry _proxyRegistry
-    ) ERC721('Nouns', 'NOUN') {
+    ) ERC721('AsoUbuyama Nouns', 'AsoUbuyama NOUN') {
         noundersDAO = _noundersDAO;
         minter = _minter;
         descriptor = _descriptor;

--- a/packages/nouns-contracts/contracts/governance/fork/newdao/token/NounsTokenFork.sol
+++ b/packages/nouns-contracts/contracts/governance/fork/newdao/token/NounsTokenFork.sol
@@ -127,7 +127,7 @@ contract NounsTokenFork is INounsTokenFork, OwnableUpgradeable, ERC721Checkpoint
         uint256 tokensToClaim,
         uint256 _forkingPeriodEndTimestamp
     ) external initializer {
-        __ERC721_init('Nouns', 'NOUN');
+        __ERC721_init('AsoUbuyama Nouns', 'AsoUbuyama NOUN');
         _transferOwnership(_owner);
         minter = _minter;
         escrow = _escrow;

--- a/packages/nouns-contracts/test/foundry/NounsToken.t.sol
+++ b/packages/nouns-contracts/test/foundry/NounsToken.t.sol
@@ -23,11 +23,11 @@ contract NounsTokenTest is Test, DeployUtils {
     }
 
     function testSymbol() public {
-        assertEq(nounsToken.symbol(), 'NOUN');
+        assertEq(nounsToken.symbol(), 'AsoUbuyama NOUN');
     }
 
     function testName() public {
-        assertEq(nounsToken.name(), 'Nouns');
+        assertEq(nounsToken.name(), 'AsoUbuyama Nouns');
     }
 
     function testMintANounToSelfAndRewardsNoundersDao() public {

--- a/packages/nouns-contracts/test/nouns.test.ts
+++ b/packages/nouns-contracts/test/nouns.test.ts
@@ -59,11 +59,11 @@ describe('NounsToken', () => {
   });
 
   it('should set symbol', async () => {
-    expect(await nounsToken.symbol()).to.eq('NOUN');
+    expect(await nounsToken.symbol()).to.eq('AsoUbuyama NOUN');
   });
 
   it('should set name', async () => {
-    expect(await nounsToken.name()).to.eq('Nouns');
+    expect(await nounsToken.name()).to.eq('AsoUbuyama Nouns');
   });
 
   it('should allow minter to mint a noun to itself', async () => {


### PR DESCRIPTION
Nounsの名称をAsoUbuyama Nounsに変更しました。
テスト部分のソースも修正済です。